### PR TITLE
解决控制开图时鼠标移动未使用配置的问题

### DIFF
--- a/thelandingchest.py
+++ b/thelandingchest.py
@@ -105,7 +105,7 @@ def enter1():
     time.sleep(time_settings.waittime_after_run)
     move(-958, 0)
     time.sleep(1)
-    turn(20, 50)
+    turn(run_settings.movetimes, run_settings.movepx)
     time.sleep(0.1)
     leftClick()
     mouseDown()


### PR DESCRIPTION
如题，我在使用时发现猎人模式未使用配置中设置的移动步数而是写死，此修改将这个问题相关的代码进行了修改