### PR TITLE
兼容低版本Python

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+Pillow
+pydirectinput

--- a/requirements_low.txt
+++ b/requirements_low.txt
@@ -1,0 +1,3 @@
+Pillow
+pydirectinput
+tomli

--- a/thelandingchest.py
+++ b/thelandingchest.py
@@ -2,7 +2,11 @@ import win32api
 import psutil
 import pydirectinput
 from pathlib import Path
-import tomllib
+import sys
+if sys.version_info >= (3, 11):
+    import tomllib
+else:
+    import tomli as tomllib
 import dataclasses
 from pydirectinput import (
     keyDown,


### PR DESCRIPTION
如题，我所使用的设备上安装了`3.10.6`版本的Python，而`tomllib`库是作为标准库在`3.11`引入的，而在此之前是名为`tomli`的非官方库。
这个提交中的修改考虑了此问题并做了兼容